### PR TITLE
Fix situations like </itemizedlist>Some text

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -505,7 +505,7 @@ MsgList StructureParser::splitMessage(const MsgBlock &mb)
                  msg1.lines.first().end_col > msg2.lines.first().start_col))
             {
                 msg2.lines.first().start_line = msg1.lines.first().end_line;
-                msg2.lines.first().start_col = msg1.lines.first().end_col;
+                msg2.lines.first().start_col = msg1.lines.first().end_col - 1;
             }
 
 #ifdef POXML_DEBUG


### PR DESCRIPTION
With XML files containing e.g.
```
<itemizedlist>
  (...)
</itemizedlist>Some text
```
one character is eaten: variable `start_col` starts at "ome text", and the translation match is not done by po2xml (`Cannot find ... in ...` message).
